### PR TITLE
Install libraries in standard locations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,14 +14,6 @@ ENABLE_LANGUAGE(CXX)
 MESSAGE(STATUS "CXX ${CMAKE_CXX_COMPILER_ID}")
 
 #===========================================================================
-# include directory path
-#===========================================================================
-
-SET(SCALFMM_CFG /usr/local/include/Utils )
-
-INCLUDE_DIRECTORIES(${SCALFMM_CFG})
-
-#===========================================================================
 # these parameters are used to build a config.h file 
 #===========================================================================
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,11 +19,9 @@ MESSAGE(STATUS "CXX ${CMAKE_CXX_COMPILER_ID}")
 
 SET(GMM_INCLUDE_DIR ../gmm-5.3/include)
 
-SET(SCALFMM_INCLUDE_DIR ../SCALFMM-1.4-148/Src )
-
 SET(SCALFMM_CFG /usr/local/include/Utils )
 
-INCLUDE_DIRECTORIES(${GMM_INCLUDE_DIR} ${SCALFMM_INCLUDE_DIR} ${SCALFMM_CFG})
+INCLUDE_DIRECTORIES(${GMM_INCLUDE_DIR} ${SCALFMM_CFG})
 
 #===========================================================================
 # these parameters are used to build a config.h file 
@@ -61,12 +59,10 @@ SET( SOURCES config.h pt3D.h matBlocDiag.h tetra.h tetra.cpp facette.h facette.c
 	linear_algebra.h linear_algebra.cpp main.cpp feellgoodSettings.cpp read.cpp femutil.cpp
 	recentering.cpp energy.cpp save.cpp solver.cpp tiny.h time_integration.cpp)
 
-SET( HEADERS ${SCALFMM_INCLUDE_DIR}/Kernels/Rotation/FRotationKernel.hpp)
-
 
 configure_file(config.h.in ./config.h)
 
-ADD_EXECUTABLE(feellgood ${SOURCES} ${HEADERS})
+ADD_EXECUTABLE(feellgood ${SOURCES})
 
 TARGET_LINK_LIBRARIES(feellgood scalfmm ANN)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,11 +17,9 @@ MESSAGE(STATUS "CXX ${CMAKE_CXX_COMPILER_ID}")
 # include directory path
 #===========================================================================
 
-SET(GMM_INCLUDE_DIR ../gmm-5.3/include)
-
 SET(SCALFMM_CFG /usr/local/include/Utils )
 
-INCLUDE_DIRECTORIES(${GMM_INCLUDE_DIR} ${SCALFMM_CFG})
+INCLUDE_DIRECTORIES(${SCALFMM_CFG})
 
 #===========================================================================
 # these parameters are used to build a config.h file 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,15 +17,13 @@ MESSAGE(STATUS "CXX ${CMAKE_CXX_COMPILER_ID}")
 # include directory path
 #===========================================================================
 
-SET(EXPRTK_INCLUDE_DIR ../exprtk )
-
 SET(GMM_INCLUDE_DIR ../gmm-5.3/include)
 
 SET(SCALFMM_INCLUDE_DIR ../SCALFMM-1.4-148/Src )
 
 SET(SCALFMM_CFG /usr/local/include/Utils )
 
-INCLUDE_DIRECTORIES(${GMM_INCLUDE_DIR} ${SCALFMM_INCLUDE_DIR} ${SCALFMM_CFG} ${EXPRTK_INCLUDE_DIR} )
+INCLUDE_DIRECTORIES(${GMM_INCLUDE_DIR} ${SCALFMM_INCLUDE_DIR} ${SCALFMM_CFG})
 
 #===========================================================================
 # these parameters are used to build a config.h file 
@@ -63,7 +61,7 @@ SET( SOURCES config.h pt3D.h matBlocDiag.h tetra.h tetra.cpp facette.h facette.c
 	linear_algebra.h linear_algebra.cpp main.cpp feellgoodSettings.cpp read.cpp femutil.cpp
 	recentering.cpp energy.cpp save.cpp solver.cpp tiny.h time_integration.cpp)
 
-SET( HEADERS ${SCALFMM_INCLUDE_DIR}/Kernels/Rotation/FRotationKernel.hpp ${EXPRTK_INCLUDE_DIR}/exprtk.hpp )
+SET( HEADERS ${SCALFMM_INCLUDE_DIR}/Kernels/Rotation/FRotationKernel.hpp)
 
 
 configure_file(config.h.in ./config.h)

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -48,3 +48,7 @@ cd ../..
 # Install GMM.
 wget -nv http://download-mirror.savannah.gnu.org/releases/getfem/stable/gmm-5.3.tar.gz
 tar xzf gmm-5.3.tar.gz
+cd gmm-5.3/
+./configure
+make
+sudo make install

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -33,11 +33,13 @@ wget -nv http://www.partow.net/downloads/exprtk.zip
 unzip exprtk.zip
 sudo cp exprtk/exprtk.hpp /usr/local/include/
 
-# Install ScalFMM.
+# Patch, build and install ScalFMM.
 wget -nv https://gforge.inria.fr/frs/download.php/file/35369/SCALFMM-1.4-148.tar.gz
 tar xzf SCALFMM-1.4-148.tar.gz
-mkdir SCALFMM-1.4-148/Build
-cd SCALFMM-1.4-148/Build
+cd SCALFMM-1.4-148/
+sed -i 's/ROtation/Rotation/' Src/CMakeLists.txt
+mkdir Build
+cd Build
 cmake ..
 make
 sudo make install

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -25,12 +25,13 @@ tar xzf ann_1.1.2.tar.gz
 cd ann_1.1.2/
 make linux-g++
 sudo cp lib/libANN.a /usr/local/lib/
-sudo cp include/ANN/ANN.h /usr/local/include
+sudo cp include/ANN/ANN.h /usr/local/include/
 cd ..
 
 # Install exprtk.
 wget -nv http://www.partow.net/downloads/exprtk.zip
 unzip exprtk.zip
+sudo cp exprtk/exprtk.hpp /usr/local/include/
 
 # Install ScalFMM.
 wget -nv https://gforge.inria.fr/frs/download.php/file/35369/SCALFMM-1.4-148.tar.gz

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -16,8 +16,9 @@ set -ev
 sudo apt-get update -q
 sudo apt-get install -y cmake libboost-dev
 
-# Install the libraries in sibling directories of FeeLLGood.
-cd ..
+# Download and build the libraries here. This is the grandparent of the
+# current directory in a Travis build.
+cd $HOME/build/
 
 # Install ANN.
 wget -nv https://www.cs.umd.edu/~mount/ANN/Files/1.1.2/ann_1.1.2.tar.gz


### PR DESCRIPTION
FeeLLGood now expects all the required libraries to be installed in a standard system directory:

 * `install-dependencies.sh` installs them in `/usr/local`, which is the
   standard location for libraries built from source.
 * `CMakeLists.txt` has no `include_directories()` command anymore.

The build of FeeLLGood does not depend anymore on the location of the library source directories. The last commit tests this assertion by moving these sources one level up the file system hierarchy.