### PR TITLE
Silence warnings from ScalFMM

### DIFF
--- a/fmm_demag.h
+++ b/fmm_demag.h
@@ -6,6 +6,8 @@ this header is the interface to scalfmm. Its purpose is to prepare an octree for
 */
 
 // scalFMM includes
+// Some of these files generate spurious warnings.
+// We silence them with "#pragma GCC diagnostic {push,ignored,pop}".
 
 #include "Utils/FTic.hpp"
 #include "Utils/FParameters.hpp"
@@ -13,13 +15,19 @@ this header is the interface to scalfmm. Its purpose is to prepare an octree for
 #include "Components/FTypedLeaf.hpp"
 #include "Components/FParticleType.hpp"
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshift-negative-value"
 #include "Containers/FOctree.hpp"
+#pragma GCC diagnostic pop
 #include "Containers/FVector.hpp"
 
 #include "Core/FFmmAlgorithmThreadTsm.hpp"
 
 #include "Kernels/P2P/FP2PParticleContainerIndexed.hpp"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
 #include "Kernels/Rotation/FRotationKernel.hpp"
+#pragma GCC diagnostic pop
 #include "Kernels/Rotation/FRotationCell.hpp"
 
 #include "fem.h"


### PR DESCRIPTION
The only compile warnings we have right now come from ScalFMM include files. I would be tempted to silence them with these gcc pragmas. There is, however, one small risk: maybe these include files are fine, and the problem is one of the templates therein is used in an incorrect fashion. If this is the case, then silencing the warnings is not the right solution.

If, on the other hand, the warnings come from sloppy ScalFMM code we have no control on, then the warnings are just noise, and the noise can prevent us from seeing other, more serious warnings. In this case, silencing the spurious warnings is a good option.

Notice that this pull request is very specific in what it silences: only

 * `-Wshift-negative-value` in `Containers/FOctree.hpp`
 * `-Wunused-parameter` in `Kernels/Rotation/FRotationKernel.hpp`

@christophe-thirion: What do you think? Do the warnings come from ScalFMM or from the way FeeLLGood uses it?