### PR TITLE
Test the behavior of `git show-ref' on Travis

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -12,6 +12,15 @@
 # -v: print the lines being executed
 set -ev
 
+# XXX: Test the behavior of `git show-ref' on Travis.
+git show-ref
+git show-ref HEAD
+git show-ref --head HEAD
+git show-ref --head HEAD --hash
+
+# Force the build to fail early.
+exit 1
+
 # Install apt packages.
 sudo apt-get update -q
 sudo apt-get install -y cmake libboost-dev

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -18,6 +18,10 @@ git show-ref HEAD
 git show-ref --head HEAD
 git show-ref --head HEAD --hash
 
+# Stricter ref matching with `--verify'.
+git show-ref --verify --head HEAD
+git show-ref --verify --head HEAD --hash
+
 # Force the build to fail early.
 exit 1
 


### PR DESCRIPTION
This is a test pull request. **Do not merge**!.

It would seem that, on pull requests, `git show-ref --head HEAD --hash` can output two different hashes.