### PR TITLE
Optimize the build time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,6 @@ compiler: g++
 install: ./install-dependencies.sh
 
 # Build script.
-script: cmake . && make
+script:
+    - cmake .
+    - make -j $(getconf _NPROCESSORS_ONLN)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,10 +42,12 @@ set( CMAKE_CXX_FLAGS "-DNDEBUG -Wall -Wextra -std=c++11 -fopenmp -O3 -march=nati
 
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fopenmp")
 
-SET( HEADERS config.h pt3D.h matBlocDiag.h tetra.h facette.h feellgoodSettings.h node.h linear_algebra.h mag_parser.h time_integration.h )
+SET(HEADERS config.h pt3D.h node.h matBlocDiag.h mag_parser.h
+    time_integration.h feellgoodSettings.h tetra.h facette.h linear_algebra.h)
 
-SET( SOURCES tetra.cpp facette.cpp linear_algebra.cpp feellgoodSettings.cpp read.cpp femutil.cpp
-	recentering.cpp energy.cpp save.cpp solver.cpp tiny.h time_integration.cpp mag_parser.cpp)
+SET(SOURCES mag_parser.cpp time_integration.cpp feellgoodSettings.cpp
+    solver.cpp tetra.cpp facette.cpp read.cpp save.cpp
+    linear_algebra.cpp femutil.cpp energy.cpp recentering.cpp tiny.h)
 
 configure_file(config.h.in ./config.h)
 

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -12,6 +12,9 @@
 # -v: print the lines being executed
 set -ev
 
+# Number of make jobs to run concurrently.
+job_count=$(getconf _NPROCESSORS_ONLN)
+
 # Install apt packages.
 sudo apt-get update -q
 sudo apt-get install -y cmake libboost-dev
@@ -24,7 +27,7 @@ cd $HOME/build/
 wget -nv https://www.cs.umd.edu/~mount/ANN/Files/1.1.2/ann_1.1.2.tar.gz
 tar xzf ann_1.1.2.tar.gz
 cd ann_1.1.2/
-make linux-g++
+make -j $job_count linux-g++
 sudo cp lib/libANN.a /usr/local/lib/
 sudo cp include/ANN/ANN.h /usr/local/include/
 cd ..
@@ -42,7 +45,7 @@ sed -i 's/ROtation/Rotation/' Src/CMakeLists.txt
 mkdir Build
 cd Build
 cmake ..
-make
+make -j $job_count
 sudo make install
 cd ../..
 
@@ -51,5 +54,5 @@ wget -nv http://download-mirror.savannah.gnu.org/releases/getfem/stable/gmm-5.3.
 tar xzf gmm-5.3.tar.gz
 cd gmm-5.3/
 ./configure
-make
+make -j $job_count
 sudo make install


### PR DESCRIPTION
This pull request attempts to optimize the build time, especially on Travis, by:

* letting `make' run multiple jobs in parallel
* starting with the sources that take longer to compile

These are the individual source compilation times, as measured on an AMD Ryzen 7 2700, sorted in decreasing order:

```text
43.485 s  mag_parser.cpp
 2.772 s  time_integration.cpp
 2.449 s  feellgoodSettings.cpp
 1.964 s  solver.cpp
 1.196 s  tetra.cpp
 0.972 s  facette.cpp
 0.941 s  read.cpp
 0.936 s  save.cpp
 0.770 s  linear_algebra.cpp
 0.715 s  femutil.cpp
 0.674 s  energy.cpp
 0.649 s  recentering.cpp
```

The cmake `SOURCES` variable has been sorted in this order, and it appears `make` follows the order of this variable.