### PR TITLE
Run Travis tests on Ubuntu 20.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 # Automatically test the build as code is pushed to GitHub.
 # This is the configuration file for Travis CI (travis-ci.org).
 
-# Test on Ubuntu 18.04 Bionic.
+# Test on Ubuntu 20.04 Focal.
 os: linux
-dist: bionic
+dist: focal
 language: cpp
 compiler: g++
 cache: ccache


### PR DESCRIPTION
This pull request is just for checking that the CI tests run fine on Focal.