### PR TITLE
Add new setting initial_time

### DIFF
--- a/default-settings.yml
+++ b/default-settings.yml
@@ -140,6 +140,12 @@ mesh:
 #   coordinates (x, y, z); the expression may be constants.
 initial_magnetization: [0, 0, 1]
 
+# Initial time of the simulation. Default is:
+# - the time recorded in the ‘.sol’ file providing the initial
+#   magnetization, if the initial magnetization was defined this way
+# - zero otherwise
+initial_time:
+
 # “Recentering” is the process by which feeLLGood tries to artificially
 # keep a domain wall in the center of the simulated volume by
 # translating the magnetization vector field.

--- a/feellgoodSettings.cpp
+++ b/feellgoodSettings.cpp
@@ -173,6 +173,11 @@ void Settings::infos()
         std::cout << "[\"" << sMx << "\", \"" << sMy << "\", \"" << sMz << "\"]\n";
     else
         std::cout << restoreFileName << "\n";
+    std::cout << "initial_time:";
+    if (isnan(initial_time))
+        std::cout << '\n';
+    else
+        std::cout << ' ' << initial_time << '\n';
     std::cout << "recentering:\n";
     std::cout << "  enable: " << str(recenter) << "\n";
     if (recenter)
@@ -399,6 +404,8 @@ void Settings::read(YAML::Node yaml)
             error("initial_magnetization should be a file name or a vector of expressions.");
             }
         }  // initial_magnetization
+
+    assign(initial_time, yaml["initial_time"]);
 
     YAML::Node recentering = yaml["recentering"];
     if (recentering)

--- a/feellgoodSettings.h
+++ b/feellgoodSettings.h
@@ -158,6 +158,9 @@ public:
     /** input file name for continuing a calculation (sol.in) */
     std::string restoreFileName;
 
+    /** initial time for the simulation, if defined in the settings file, NAN otherwise */
+    double initial_time = NAN;
+
     /** maximum value for du step */
     double DUMAX;  // 0.1 for magnetostatic simulations; 0.02 for the dynamics
 

--- a/fem.h
+++ b/fem.h
@@ -112,6 +112,12 @@ public:
             t_prm.set_t(msh.readSol(mySets.verbose, mySets.restoreFileName));
             }
 
+        /* This potentially overrides the initial time set above by msh.readSol(). */
+        if (!isnan(mySets.initial_time))
+            {
+            t_prm.set_t(mySets.initial_time);
+            }
+
         if (mySets.recenter)
             {
             direction(Nodes::IDX_Z);


### PR DESCRIPTION
The initial time of the simulation is:

 * zero if the initial magnetization is provided by a function or a set of analytic expressions (including the default: [0, 0, 1])

 * the time recorded in the .sol file if such a file is used to set the initial magnetization

The latter is a sensible choice when the user wants to continue a simulation that was previously interrupted. It is common, however, to perform one simulation with a big alpha, only to get an initial, relaxed state for a subsequent simulation. In this case, one would want the time to be reset to zero for the second simulation.

This pull request adds a new parameter `initial_time` to the YAML settings file, to let the user explicitly set the initial simulation time. If unset, the current default behavior applies.