### PR TITLE
clean log displays

### DIFF
--- a/src/algebra/bicg.h
+++ b/src/algebra/bicg.h
@@ -165,7 +165,7 @@ T bicg_dir(iteration<T> &iter, SparseMatrix& A, std::vector<T> & x,
     {
     T rho_1(0.0), rho_2(0.0), alpha(0.0), beta(0.0), omega(0.0);
     const size_t DIM = x.size();
-    if (rhs.size()!=DIM){std::cout << "rhs size mismatch" << std::endl; exit(1);}
+    if (rhs.size()!=DIM) { std::cerr << "rhs size mismatch" << "\n"; exit(1); }
 
     std::vector<T> p(DIM), phat(DIM), shat(DIM);
     std::vector<T> r(DIM), rt(DIM), s(DIM), t(DIM), v(DIM), diag_precond(DIM), b(rhs);

--- a/src/algebra/iter.h
+++ b/src/algebra/iter.h
@@ -7,7 +7,7 @@
 \brief iteration class from GMM, with some adaptations and simplifications.
 
 The Iteration object calculates if the solution has reached the desired accuracy,
- or if the maximum number of iterations has been reached.
+or if the maximum number of iterations has been reached.
 
 The method finished() checks the convergence.
 */
@@ -171,7 +171,7 @@ class iteration
             T a = (rhsn == 0) ? 1.0 : rhsn;
             converged(nr);
             std::cout << " iter " << std::setw(3) << nit
-                    << " residual " << std::setw(12) << std::fabs(nr) / a << std::endl;
+                    << " residual " << std::setw(12) << std::fabs(nr) / a << "\n";
             written = true;
             }
         return converged(nr);

--- a/src/electrostatSolver.cpp
+++ b/src/electrostatSolver.cpp
@@ -18,7 +18,7 @@ void electrostatSolver::checkBoundaryConditions(void) const
         });
     if (!(nbSurfJ == 1 && nbSurfV == 1))
         {
-        std::cout << "Error: incorrect boundary conditions for potential V solver.\n";
+        std::cerr << "Error: incorrect boundary conditions for potential V solver.\n";
         exit(1);
         }
     else if (verbose)
@@ -30,8 +30,8 @@ void electrostatSolver::infos(void) const
     std::cout << "Boundary conditions:\n";
     std::for_each(paramTri.begin(),paramTri.end(),[](const Triangle::prm &p)
         {
-        if (!std::isnan(p.jn)) { std::cout << "\tjn= " << p.jn << std::endl; }
-        if (!std::isnan(p.V)) { std::cout << "\tV= " << p.V << std::endl; }
+        if (!std::isnan(p.jn)) { std::cout << "\tjn= " << p.jn << "\n"; }
+        if (!std::isnan(p.V)) { std::cout << "\tV= " << p.V << "\n"; }
         } );
     }
 
@@ -75,7 +75,7 @@ void electrostatSolver::compute(const bool verbose, const std::string& V_fileNam
     {
     bool has_converged = solve();
     if (verbose)
-        { std::cout << "electrostatic solver: " << iter.infos() << std::endl; }
+        { std::cout << "electrostatic solver: " << iter.infos() << "\n"; }
     if (has_converged)
         {
         if (!V_fileName.empty())
@@ -136,7 +136,7 @@ bool electrostatSolver::save(const std::string& V_fileName, const std::string &m
     std::ofstream fout(V_fileName, std::ios::out);
     if (fout.fail())
         {
-        std::cout << "cannot open file " << V_fileName << std::endl;
+        std::cerr << "cannot open file " << V_fileName << "\n";
         SYSTEM_ERROR;
         }
 
@@ -146,7 +146,7 @@ bool electrostatSolver::save(const std::string& V_fileName, const std::string &m
     for (int i = 0; i < NOD; i++)
         {
         int _i = msh->getNodeIndex(i);
-        fout << i << '\t' << V[_i] << std::endl;
+        fout << i << '\t' << V[_i] << "\n";
         }
     fout.close();
     return !(fout.good());

--- a/src/fem.h
+++ b/src/fem.h
@@ -57,10 +57,11 @@ public:
                 {
                 std::cout << "Approximate nearest neighbors:\n";
                 }
+
             pts = annAllocPts(msh.getNbNodes(), Nodes::DIM);
             if (!pts)
                 {
-                std::cout << "ANN memory error while allocating points" << std::endl;
+                std::cerr << "ANN memory error while allocating points\n";
                 SYSTEM_ERROR;
                 }
             else if (mySets.verbose)
@@ -83,7 +84,7 @@ public:
             kdtree = new ANNkd_tree(pts, msh.getNbNodes(), Nodes::DIM);
             if (!kdtree)
                 {
-                std::cout << "ANN memory error while allocating kd_tree" << std::endl;
+                std::cerr << "ANN memory error while allocating kd_tree\n";
                 SYSTEM_ERROR;
                 }
             recenter_mem = true;
@@ -140,7 +141,7 @@ public:
 
     /** initial total energy */
     double Etot0;
-    
+
     /** total energy */
     double Etot;
 
@@ -209,13 +210,13 @@ private:
             { success = true; }
         if (settings.verbose)
             {
-            std::cout << "magnetostatics done in " << fmm_counter.millis() << std::endl;
+            std::cout << "magnetostatics done in " << fmm_counter.millis() << "\n";
             if (settings.spin_acc)
                 {
                 if (success)
                     { std::cout << "spin diffusion solved.\n"; }
                 else
-                    { std::cout << "spin diffusion solver failed.\n"; }
+                    { std::cerr << "spin diffusion solver failed.\n"; }
                 }
             }
         energy(t, settings);

--- a/src/read.cpp
+++ b/src/read.cpp
@@ -16,18 +16,18 @@ void mesh::readMesh(const Settings &mySets)
         { gmsh::option::setNumber("General.Terminal",0); } // to silent gmsh
     checkMeshFile(mySets);
     if (mySets.verbose)
-        { std::cout<< "Checking mesh file: done.\n"; }
+        { std::cout << "Checking mesh file: done.\n"; }
     readNodes(mySets);
     if (mySets.verbose)
-        { std::cout<< "Nodes loaded.\n"; }
+        { std::cout << "Nodes loaded.\n"; }
     readTetraedrons(mySets);
     for (unsigned int i = 0; i < tet.size(); i++)
         { tet[i].idx = i; }
     if (mySets.verbose)
-        { std::cout<< "Tetraedrons built.\n"; }
+        { std::cout << "Tetraedrons built.\n"; }
     readTriangles(mySets);
     if (mySets.verbose)
-        { std::cout<< "triangles built.\n"; }
+        { std::cout << "triangles built.\n"; }
     gmsh::clear();
     gmsh::finalize();
     }
@@ -36,17 +36,20 @@ void mesh::checkMeshFile(const Settings &mySets)
     {
     using namespace tags::msh;
     gmsh::open(mySets.getPbName());
-    
+
     bool msh_available = (gmsh::model::getDimension() == DIM_OBJ_3D);
     if (!msh_available)
-        { std::cout<<"Fatal Error: mesh file " << mySets.getPbName() << " is not 3D\n"; exit(1); }
+        {
+        std::cerr << "Fatal Error: mesh file " << mySets.getPbName() << " is not 3D\n";
+        exit(1);
+        }
     std::vector<int> elemTypes;
     gmsh::model::mesh::getElementTypes(elemTypes, DIM_OBJ_3D, -1);
     msh_available = msh_available && (elemTypes.size() == 1); // only one type of 3D element allowed
     msh_available = msh_available && (elemTypes[0] == TYP_ELEM_TETRAEDRON); // only Tetrahedrons
     if (!msh_available)
         {
-        std::cout<<"Fatal Error: mesh file contains other 3D elements than tetraedrons.\n";
+        std::cerr << "Fatal Error: mesh file contains other 3D elements than tetraedrons.\n";
         exit(1);
         }
     gmsh::model::mesh::getElementTypes(elemTypes, DIM_OBJ_2D, -1);
@@ -54,14 +57,14 @@ void mesh::checkMeshFile(const Settings &mySets)
     msh_available = msh_available && (elemTypes[0] == TYP_ELEM_TRIANGLE); // only Triangles
     if (!msh_available)
         {
-        std::cout<<"Fatal Error: mesh file contains other 2D elements than triangles.\n";
+        std::cerr << "Fatal Error: mesh file contains other 2D elements than triangles.\n";
         exit(1);
         }
     bool o_2D = checkNamedObjects<Triangle::prm>(mySets.paramTriangle,DIM_OBJ_2D);
     bool o_3D = checkNamedObjects<Tetra::prm>(mySets.paramTetra,DIM_OBJ_3D);
     if (!(o_2D && o_3D))
         {
-        std::cout <<"Fatal Error: mismatch between input mesh file and yaml regions.\n";
+        std::cerr << "Fatal Error: mismatch between input mesh file and yaml regions.\n";
         exit(1);
         }
     }
@@ -132,7 +135,7 @@ void mesh::readTetraedrons(const Settings &mySets /**< [in] */)
                         }
                     else
                         {
-                        std::cout << "Fatal error: "
+                        std::cerr << "Fatal error: "
                                 "a volume mesh entity contains other elements than tetraedrons.\n";
                         exit(1);
                         }
@@ -182,7 +185,7 @@ void mesh::readTriangles(const Settings &mySets /**< [in] */)
                         }
                     else
                         {
-                        std::cout << "Fatal error: "
+                        std::cerr << "Fatal error: "
                                 "a surface mesh entity contains other elements than triangles.\n";
                         exit(1);
                         }
@@ -216,13 +219,13 @@ double mesh::readSol(bool VERBOSE, const std::string& fileName)
 
     if (!flag_t)
         {
-        std::cerr << "error: no ## time: tag in input .sol file " << fileName << std::endl;
+        std::cerr << "error: no ## time: tag in input .sol file " << fileName << "\n";
         SYSTEM_ERROR;
         }
 
     if (VERBOSE)
         {
-        std::cout << ".sol file: " << fileName << " @ time t = " << t << std::endl;
+        std::cout << ".sol file: " << fileName << " @ time t = " << t << "\n";
         }
 
     for (unsigned int i = 0; i < node.size(); i++)
@@ -234,8 +237,7 @@ double mesh::readSol(bool VERBOSE, const std::string& fileName)
         node[node_idx].d[Nodes::NEXT].u = Eigen::Vector3d(mx,my,mz);
         if (i != i_)
             {
-            std::cerr << "error: mesh node index mismatch between mesh and input .sol file"
-                      << std::endl;
+            std::cerr << "error: mesh node index mismatch between mesh and input .sol file\n";
             fin.close();
             SYSTEM_ERROR;
             }

--- a/src/recentering.cpp
+++ b/src/recentering.cpp
@@ -93,7 +93,7 @@ bool Fem::recenter(double thres, const char recentering_direction)
     double u2R = msh.getNode_u(ns)(idx_dir);
     if (u2L * u2R > 0)
         {
-        std::cout << "Error No Domain Wall" << std::endl;
+        std::cerr << "Error No Domain Wall\n";
         SYSTEM_ERROR;
         }
 

--- a/src/save.cpp
+++ b/src/save.cpp
@@ -8,10 +8,9 @@
 
 #include "chronometer.h"
 
-using namespace std;
 using namespace Nodes;
 
-void Fem::saver(Settings &settings, const timing &t_prm, ofstream &fout, const int nt,
+void Fem::saver(Settings &settings, const timing &t_prm, std::ofstream &fout, const int nt,
         std::vector<Eigen::Vector3d> &s) const
     {
     int save_period = settings.save_period;
@@ -142,22 +141,22 @@ void Fem::saver(Settings &settings, const timing &t_prm, ofstream &fout, const i
         }
     fout << std::flush;
 
-    string baseName = settings.r_path_output_dir + '/' + settings.getSimName();
+    std::string baseName = settings.r_path_output_dir + '/' + settings.getSimName();
 
     if (save_period && (nt % save_period) == 0)
         {
-        string str = baseName + "_iter" + to_string(nt) + ".sol";
+        std::string str = baseName + "_iter" + std::to_string(nt) + ".sol";
 
         if (settings.verbose)
             {
-            cout << " " << str << endl;
+            std::cout << " " << str << "\n";
             }
 
-        string metadata = settings.solMetadata(t_prm.get_t());
+        std::string metadata = settings.solMetadata(t_prm.get_t());
         msh.savesol(settings.getPrecision(), str, metadata, settings.spin_acc, s);
         if (settings.verbose)
             {
-            cout << "all nodes written." << endl;
+            std::cout << "all nodes written.\n";
             }
         }
     }
@@ -165,10 +164,10 @@ void Fem::saver(Settings &settings, const timing &t_prm, ofstream &fout, const i
 void Mesh::mesh::savesol(const int precision, const std::string& fileName,
         const std::string &metadata, bool withSpinAcc, std::vector<Eigen::Vector3d> &s) const
     {
-    ofstream fout(fileName, ios::out);
+    std::ofstream fout(fileName, std::ios::out);
     if (fout.fail())
         {
-        std::cout << "cannot open file " << fileName << std::endl;
+        std::cerr << "cannot open file " << fileName << "\n";
         SYSTEM_ERROR;
         }
 
@@ -181,8 +180,7 @@ void Mesh::mesh::savesol(const int precision, const std::string& fileName,
         fout << i << '\t' << dn.u.format(outputSolFmt) << '\t' << dn.phi;
         if (withSpinAcc)
             { fout << '\t' << s[j].format(outputSolFmt); }
-        fout << endl;
+        fout << "\n";
         }
     fout.close();
     }
-

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -18,7 +18,7 @@ bool LinAlgebra::solve(const timing &t_prm)
 
     if (verbose)
         {
-        std::cout << "matrix assembly done in " << counter.millis() << std::endl;
+        std::cout << "matrix assembly done in " << counter.millis() << "\n";
         counter.reset();
         }
 
@@ -49,7 +49,7 @@ bool LinAlgebra::solve(const timing &t_prm)
     std::for_each(lvd.begin(),lvd.end(),[this](const int i){ K.set(i,i,1.0); });
     if (verbose)
         {
-        std::cout << "matrix assembly done in " << counter.millis() << std::endl;
+        std::cout << "matrix assembly done in " << counter.millis() << "\n";
         counter.reset();
         }
     /*
@@ -65,12 +65,12 @@ bool LinAlgebra::solve(const timing &t_prm)
             || (iter.get_res() > iter.resmax))
         {
         if (verbose)
-            { std::cout << "solver: " << iter.infos() << std::endl; }
+            { std::cout << "solver: " << iter.infos() << "\n"; }
         return true;
         }
 
     if (verbose)
-        { std::cout << "solver: " << iter.infos() <<  " in " << counter.millis() << std::endl; }
+        { std::cout << "solver: " << iter.infos() <<  " in " << counter.millis() << "\n"; }
 
     double v2max(0.0);
     const double dt = t_prm.get_dt();

--- a/src/spinAccumulationSolver.cpp
+++ b/src/spinAccumulationSolver.cpp
@@ -30,7 +30,7 @@ using namespace Nodes;
             prepareExtraField();
             if(!compute())
                 {
-                std::cout << "Error: spin diffusion solver(first try) failed.\n";
+                std::cerr << "Error: spin diffusion solver(first try) failed.\n";
                 exit(1);
                 }
             }
@@ -66,7 +66,7 @@ void spinAcc::checkBoundaryConditions(void) const
 
     if (!result)
         {
-        std::cout << "Error: incorrect boundary conditions for spin diffusion solver.\n";
+        std::cerr << "Error: incorrect boundary conditions for spin diffusion solver.\n";
         exit(1);
         }
     else if (verbose)
@@ -148,7 +148,7 @@ bool spinAcc::compute(void)
     bool has_converged = solve();
     if (!has_converged)
         {
-        std::cout << "spin accumulation solver: " << iter.infos() << std::endl;
+        std::cout << "spin accumulation solver: " << iter.infos() << "\n";
         for(int i=0;i<NOD;i++)
             { s[i].setZero(); }
         }

--- a/src/tags.cpp
+++ b/src/tags.cpp
@@ -8,8 +8,7 @@ void on_fail_msg_error(const std::ifstream &f_in, const std::string& strWhat)
     {
     if (f_in.fail())
         {
-        std::cerr << strWhat << ": " << strerror(errno) << std::endl;
+        std::cerr << strWhat << ": " << strerror(errno) << "\n";
         exit(1);
         }
     }
-


### PR DESCRIPTION
More cleaning, mostly replacing std::endl with "\n" and fixing the errors which were printed with std::cout so std::cerr is used instead.